### PR TITLE
Travis CI: Lint for Python syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: python
+install: pip install flake8
+script: flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics


### PR DESCRIPTION
https://travis-ci.com/IBM/kube-safe-scheduler/builds/114661698#L459