### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/node-annotator/prom_query.py
+++ b/node-annotator/prom_query.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import csv
 import requests
 import time
@@ -69,7 +70,7 @@ class FetchData:
             FetchData.write_csv(results) # this is optional
 
 
-            print FetchData.data["value"].mean(), FetchData.data["value"].std(), FetchData.data["value"].min()
+            print(FetchData.data["value"].mean(), FetchData.data["value"].std(), FetchData.data["value"].min())
 
             #curate the data
             if requested > 0:
@@ -172,7 +173,7 @@ class FetchData:
             predicted = output[0]
             print('predicted = %f' % (predicted))
         except Exception as e:
-            print ("ARIMA error occured while predicting: ", e)
+            print(("ARIMA error occured while predicting: ", e))
             return
         #error = mean_squared_error(test, predictions) # needed to optimize the params (future work).
         #print('Test MSE: %.3f' % error)

--- a/vendor/k8s.io/kubernetes/cluster/juju/return-node-ips.py
+++ b/vendor/k8s.io/kubernetes/cluster/juju/return-node-ips.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
 import json
 import sys
 # This script helps parse out the private IP addresses from the
@@ -24,6 +25,6 @@ if len(sys.argv) > 1:
     nodes = json.loads(sys.argv[1])
     # There can be multiple nodes to print the Stdout.
     for num in nodes:
-        print num['Stdout'].rstrip()
+        print(num['Stdout'].rstrip())
 else:
     exit(1)

--- a/vendor/k8s.io/kubernetes/hack/update_owners.py
+++ b/vendor/k8s.io/kubernetes/hack/update_owners.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
 import argparse
 import collections
 import csv
@@ -178,24 +179,24 @@ def main():
         f.write(prefixes + '\n')
 
     if options.print_sig_prefixes:
-        print prefixes
+        print(prefixes)
         return
 
     outdated_tests = sorted(set(owners) - set(test_names))
     new_tests = sorted(set(test_names) - set(owners))
     maintainers = get_maintainers()
 
-    print '# OUTDATED TESTS (%d):' % len(outdated_tests)
-    print  '\n'.join('%s -- %s%s' %
+    print('# OUTDATED TESTS (%d):' % len(outdated_tests))
+    print('\n'.join('%s -- %s%s' %
                      (t, owners[t][0], ['', ' (random)'][owners[t][1]])
-                      for t in outdated_tests)
-    print '# NEW TESTS (%d):' % len(new_tests)
-    print  '\n'.join(new_tests)
+                      for t in outdated_tests))
+    print('# NEW TESTS (%d):' % len(new_tests))
+    print('\n'.join(new_tests))
 
     if options.check:
         if new_tests or outdated_tests:
-            print
-            print 'ERROR: the test list has changed'
+            print()
+            print('ERROR: the test list has changed')
             sys.exit(1)
         sys.exit(0)
 
@@ -206,13 +207,13 @@ def main():
         owners.pop(name)
 
     if not options.addonly:
-        print '# UNEXPECTED MAINTAINERS ',
-        print '(randomly assigned, but not in kubernetes-maintainers)'
+        print('# UNEXPECTED MAINTAINERS ', end=' ')
+        print('(randomly assigned, but not in kubernetes-maintainers)')
         for name, (owner, random_assignment, _) in sorted(owners.iteritems()):
             if random_assignment and owner not in maintainers:
-                print '%-16s %s' % (owner, name)
+                print('%-16s %s' % (owner, name))
                 owners.pop(name)
-        print
+        print()
 
     owner_counts = collections.Counter(
         owner for name, (owner, random, sig) in owners.iteritems()
@@ -228,9 +229,9 @@ def main():
         owners[test_name] = (new_owner, random_assignment, "")
 
     if options.user.lower() == 'random':
-        print '# Tests per maintainer:'
+        print('# Tests per maintainer:')
         for owner, count in owner_counts.most_common():
-            print '%-20s %3d' % (owner, count)
+            print('%-20s %3d' % (owner, count))
 
     write_owners(OWNERS_PATH, owners)
 

--- a/vendor/k8s.io/kubernetes/hack/verify-flags-underscore.py
+++ b/vendor/k8s.io/kubernetes/hack/verify-flags-underscore.py
@@ -35,7 +35,7 @@ def is_binary(pathname):
     try:
         with open(pathname, 'r') as f:
             CHUNKSIZE = 1024
-            while 1:
+            while True:
                 chunk = f.read(CHUNKSIZE)
                 if '\0' in chunk: # found null byte
                     return True
@@ -110,8 +110,7 @@ def check_underscore_in_flags(rootdir, files):
     if len(new_excluded_flags) != 0:
         print("Found a flag declared with an _ but which is not explicitly listed as a valid flag name in hack/verify-flags/excluded-flags.txt")
         print("Are you certain this flag should not have been declared with an - instead?")
-        l = list(new_excluded_flags)
-        l.sort()
+        l = sorted(new_excluded_flags)
         print("%s" % "\n".join(l))
         sys.exit(1)
 

--- a/vendor/k8s.io/kubernetes/hack/verify-flags-underscore.py
+++ b/vendor/k8s.io/kubernetes/hack/verify-flags-underscore.py
@@ -110,8 +110,7 @@ def check_underscore_in_flags(rootdir, files):
     if len(new_excluded_flags) != 0:
         print("Found a flag declared with an _ but which is not explicitly listed as a valid flag name in hack/verify-flags/excluded-flags.txt")
         print("Are you certain this flag should not have been declared with an - instead?")
-        l = sorted(new_excluded_flags)
-        print("%s" % "\n".join(l))
+        print("%s" % "\n".join(sorted(new_excluded_flags)))
         sys.exit(1)
 
 def main():


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.  Fixes issues discovered in #3 